### PR TITLE
Add admin CLI, dashboard and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+MONGO_URI=mongodb://localhost:27017/roblox
+API_KEY=your-api-key
+JWT_SECRET=supersecret
+SCHEMA_VERSION=1
+PORT=5000
+ALLOWED_IPS=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .env
 .env.*
+!.env.example
 *.log
 /dashboard/node_modules
 /admin-cli/node_modules

--- a/README.md
+++ b/README.md
@@ -1,14 +1,45 @@
 # Roblox Backend Service
 
-This repository provides a basic backend for synchronizing Roblox player data across games using Node.js, Express and MongoDB. It contains placeholder implementations for a REST API, CLI utility and React dashboard.
+This repository provides a simple backend for synchronizing Roblox player data across games using Node.js, Express and MongoDB.  It exposes a REST API, a small command line utility and a very light React based dashboard.
 
 ## Development
 
-Copy `.env.example` to `.env` and adjust values. Then run:
+Copy `.env.example` to `.env` and adjust values.  After installing dependencies you can start the server with:
 
 ```bash
 npm install
 npm start
 ```
 
-Docker and docker-compose configurations are included.
+Docker and docker-compose configurations are included for local development.
+
+### CLI
+
+```
+node admin-cli/main.js create-admin <user> <pass>
+```
+
+Additional commands such as `get`, `backup`, `migrate`, `history` and `users` are available. Run the script without arguments to see them all.
+
+### Roblox Example
+
+Send player data from a Roblox game:
+
+```lua
+local HttpService = game:GetService("HttpService")
+HttpService:PostAsync(
+    "https://your-server/api/user/save",
+    HttpService:JSONEncode({userId = player.UserId, coins = 100}),
+    Enum.HttpContentType.ApplicationJson,
+    false,
+    { ["x-api-key"] = "your-api-key" }
+)
+```
+
+Load data back in another game:
+
+```lua
+local res = HttpService:GetAsync("https://your-server/api/user/load?userId=" .. player.UserId, false, { ["x-api-key"] = "your-api-key" })
+local data = HttpService:JSONDecode(res)
+print(data.coins)
+```

--- a/admin-cli/main.js
+++ b/admin-cli/main.js
@@ -7,6 +7,7 @@ const userService = require('../src/services/userService');
 const backupService = require('../src/services/backupService');
 const migrationService = require('../src/services/migrationService');
 const historyService = require('../src/services/historyService');
+const adminService = require('../src/services/adminService');
 
 async function init() { await connectDB(); }
 
@@ -25,5 +26,23 @@ program
 program
   .command('history <userId>')
   .action(async (id) => { await init(); const h = await historyService.listHistory(id); console.log(h); process.exit(); });
+
+program
+  .command('create-admin <username> <password>')
+  .action(async (username, password) => {
+    await init();
+    const admin = await adminService.createAdmin(username, password);
+    console.log(admin);
+    process.exit();
+  });
+
+program
+  .command('users')
+  .action(async () => {
+    await init();
+    const users = await adminService.listUsers();
+    console.log(users);
+    process.exit();
+  });
 
 program.parse(process.argv);

--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -1,5 +1,51 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function App() {
-  return <div>Admin Dashboard Placeholder</div>;
+  const [token, setToken] = useState(localStorage.getItem('token') || '');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [users, setUsers] = useState([]);
+
+  const login = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    const data = await res.json();
+    if (data.token) {
+      localStorage.setItem('token', data.token);
+      setToken(data.token);
+    }
+  };
+
+  useEffect(() => {
+    if (!token) return;
+    fetch('/api/admin/users', {
+      headers: { Authorization: 'Bearer ' + token }
+    }).then(res => res.json()).then(setUsers).catch(() => {});
+  }, [token]);
+
+  if (!token) {
+    return (
+      <form onSubmit={login}>
+        <h2>Admin Login</h2>
+        <input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <button type="submit">Login</button>
+      </form>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Users</h2>
+      <ul>
+        {users.map(u => (
+          <li key={u._id || u.userId}>{u.userId}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/middleware/apiKeyCheck.js
+++ b/src/middleware/apiKeyCheck.js
@@ -1,6 +1,0 @@
-module.exports = function(req, res, next) {
-  if (req.headers["x-api-key"] !== process.env.API_KEY) {
-    return res.status(401).json({ error: "Unauthorized" });
-  }
-  next();
-};

--- a/src/services/adminService.js
+++ b/src/services/adminService.js
@@ -1,4 +1,6 @@
 const User = require('../models/UserData');
+const Admin = require('../models/Admin');
+const bcrypt = require('bcryptjs');
 
 async function banUser(id) {
   return User.deleteOne({ userId: id });
@@ -8,4 +10,9 @@ async function listUsers() {
   return User.find().select('userId');
 }
 
-module.exports = { banUser, listUsers };
+async function createAdmin(username, password, role = 'full') {
+  const passwordHash = await bcrypt.hash(password, 10);
+  return Admin.create({ username, passwordHash, role });
+}
+
+module.exports = { banUser, listUsers, createAdmin };


### PR DESCRIPTION
## Summary
- add example environment file
- ignore `*.env` but track `.env.example`
- implement admin account creation and user listing in CLI
- support creating admins in admin service
- build a minimal React dashboard with login and user list
- document CLI usage and Roblox API example
- remove unused apiKeyCheck middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884a31e5dcc8328a6d6a9c711c629c3