### PR TITLE
Fix root endpoint health check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,8 @@ app.use(express.json());
 app.use(logger);
 
 app.use(rateLimit({ windowMs: 60 * 1000, max: 60 }));
-app.use(apiKeyCheck);
 
-app.use('/api', routes);
+app.use('/api', apiKeyCheck, routes);
 app.get('/', (req, res) => {
   res.send('Roblox Backend Service is running.');
 });


### PR DESCRIPTION
## Summary
- allow health check HEAD/GET requests to `/` without API key

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884b530559c8328a57122fefa31c420